### PR TITLE
Add Hasar P-HAS-181 printer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ if ( PPDC )
 	list (APPEND PPDS "${PPDDIR}/xp58.ppd" )
 	list (APPEND PPDS "${PPDDIR}/tm20.ppd" )
 	list (APPEND PPDS "${PPDDIR}/zj80.ppd" )
+	list (APPEND PPDS "${PPDDIR}/has181.ppd" )
 	ADD_CUSTOM_COMMAND ( OUTPUT ${PPDS}
 			COMMAND LANG=c ${PPDC} ${DRVSRC}
 			MAIN_DEPENDENCY ${DRVSRC}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ if ( PPDC )
 	list (APPEND PPDS "${PPDDIR}/tm20.ppd" )
 	list (APPEND PPDS "${PPDDIR}/zj80.ppd" )
 	list (APPEND PPDS "${PPDDIR}/has181.ppd" )
+	list (APPEND PPDS "${PPDDIR}/KrossTPT700.ppd" )
 	ADD_CUSTOM_COMMAND ( OUTPUT ${PPDS}
 			COMMAND LANG=c ${PPDC} ${DRVSRC}
 			MAIN_DEPENDENCY ${DRVSRC}
@@ -113,4 +114,3 @@ elseif ( UNIX )
 endif()
 
 include (CPack)
-

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Zj-58, Zj-80 and other receipt printers
 =======================================
 
-CUPS filter for cheap thermal receipt printers as Zijiang ZJ-58, XPrinter XP-58, JZ-80 with cutter, Epson TM-T20, Hasar P-HAS-181, and may be any other printers understanding ESC/POS commands.
+CUPS filter for cheap thermal receipt printers as Zijiang ZJ-58, XPrinter XP-58, JZ-80 with cutter, Epson TM-T20, Hasar P-HAS-181, kross TP-T 700 and may be any other printers understanding ESC/POS commands.
 
 Originally it was reverse-engineered filter for Zijiang zj-58 with it's specific PPD, but later it is revealed that it actually works with many other cheap 58mm printers, like Xprinter XP-58.
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
 Zj-58, Zj-80 and other receipt printers
 =======================================
 
-CUPS filter for cheap thermal receipt printers as Zijiang ZJ-58, XPrinter XP-58, JZ-80 with cutter, Epson TM-T20, and may be any other printers understanding ESC/POS commands.
+CUPS filter for cheap thermal receipt printers as Zijiang ZJ-58, XPrinter XP-58, JZ-80 with cutter, Epson TM-T20, Hasar P-HAS-181, and may be any other printers understanding ESC/POS commands.
 
-Originally it was reverse-engineered filter for Zijiang zj-58 with it's specific PPD,
-but later it is revealed that it actually works with many other cheap 58mm printers, like
-Xprinter XP-58.
+Originally it was reverse-engineered filter for Zijiang zj-58 with it's specific PPD, but later it is revealed that it actually works with many other cheap 58mm printers, like Xprinter XP-58.
 
 Features
 --------

--- a/zjdrv.drv
+++ b/zjdrv.drv
@@ -215,5 +215,37 @@ Installable "OptionCutter/Cutter"
     Attribute "Product" "" "(tm-t20)"
     Attribute "1284DeviceID" "" "MFG:Epson;CMD:Epson;MDL:TMT20;CLS:PRINTER;"
   }
+  // Hasar P-Has-181
+  {
+    Manufacturer "Hasar"
+    ModelName "P-HAS-181"
+    PCFileName "has181.ppd"
+    Attribute "NickName" "" "Hasar Has-181"
+    Attribute "ShortNickName" "" "HAS-181"
+    Attribute "Product" "" "(Has-181)"
+    Attribute "0100DeviceID" "" "MFG:Gainscha;CMD:Hasar;MDL:HAS181;CLS:PRINTER;"  
+Installable "OptionCutter/Cutter"
+    UIConstraints "*CutMedia *OptionCutter True"
+  Option "CutMedia/Cut Media" PickOne AnySetup 10
+    Choice "None/No cutting" "<</CutMedia 0>>setpagedevice"
+    Choice "EndOfPage/Cut at every page" "<</CutMedia 4>>setpagedevice"
+   *Choice "EndOfJob/Cut at every job" "<</CutMedia 2>>setpagedevice"
+Group "BlankGroup/Blank Options"
+  Option "FeedDist/Feed distance" PickOne AnySetup 10
+    Choice "0feed3mm/3mm" "<</AdvanceDistance 24>>setpagedevice"
+    Choice "1feed6mm/6mm" "<</AdvanceDistance 48>>setpagedevice"
+    Choice "2feed9mm/9mm" "<</AdvanceDistance 72>>setpagedevice"
+    Choice "3feed12mm/12mm" "<</AdvanceDistance 96>>setpagedevice"
+    Choice "4feed15mm/15mm" "<</AdvanceDistance 120>>setpagedevice"
+    Choice "5feed18mm/18mm" "<</AdvanceDistance 144>>setpagedevice"
+    Choice "6feed21mm/21mm" "<</AdvanceDistance 168>>setpagedevice"
+    Choice "7feed24mm/24mm" "<</AdvanceDistance 192>>setpagedevice"
+    Choice "8feed27mm/27mm" "<</AdvanceDistance 216>>setpagedevice"
+    *Choice "9feed30mm/30mm" "<</AdvanceDistance 240>>setpagedevice"
+    Choice "10feed33mm/33mm" "<</AdvanceDistance 264>>setpagedevice"
+    Choice "11feed36mm/36mm" "<</AdvanceDistance 288>>setpagedevice"
+    Choice "12feed39mm/39mm" "<</AdvanceDistance 312>>setpagedevice"
+    Choice "13feed42mm/42mm" "<</AdvanceDistance 336>>setpagedevice"
+    Choice "14feed45mm/45mm" "<</AdvanceDistance 360>>setpagedevice"
+   }
 }
-

--- a/zjdrv.drv
+++ b/zjdrv.drv
@@ -248,4 +248,24 @@ Group "BlankGroup/Blank Options"
     Choice "13feed42mm/42mm" "<</AdvanceDistance 336>>setpagedevice"
     Choice "14feed45mm/45mm" "<</AdvanceDistance 360>>setpagedevice"
    }
+     // Kross TP-T 700
+  {
+    Manufacturer "Kross"
+    ModelName "TP-T 700"
+    PCFileName "KrossTPT700.ppd"
+    Attribute "NickName" "" "Kross TP-T 700"
+    Attribute "ShortNickName" "" "TP-T 700"
+    Attribute "Product" "" "(TP-T700)"
+    Attribute "0100DeviceID" "" "MFG:Kross;CMD:Kross;MDL:KROSSTP700;CLS:PRINTER;"  
+Installable "OptionCutter/Cutter"
+    UIConstraints "*CutMedia *OptionCutter True"
+  Option "CutMedia/Cut Media" PickOne AnySetup 10
+    Choice "None/No cutting" "<</CutMedia 0>>setpagedevice"
+    Choice "EndOfPage/Cut at every page" "<</CutMedia 4>>setpagedevice"
+   *Choice "EndOfJob/Cut at every job" "<</CutMedia 2>>setpagedevice"
+Group "BlankGroup/Blank Options"
+  Option "FeedDist/Feed distance" PickOne AnySetup 10
+    *Choice "4feed15mm/15mm" "<</AdvanceDistance 120>>setpagedevice"
+    Choice "5feed18mm/18mm" "<</AdvanceDistance 144>>setpagedevice"
+  }
 }


### PR DESCRIPTION
Add support for Hasar P-HAS-181 printer
solution to my problem, on issue https://github.com/klirichek/zj-58/issues/39
.
This printer: [Hasar p-181](https://compania.grupohasar.com/producto/p-has-181/). is pretty popular in Argentina, and is a rebrand of model of [Gainscha GP-C80180I](https://www.gainscha.net/products_show.asp?lan=zh-en&skin=2&newsid=473100368).
Tested with USB versión of printer and working fine on Manjaro and CUPS 2.4.2

![Print](https://user-images.githubusercontent.com/44300977/181867374-290dca59-b02b-4356-8fc9-27e9fa1bfe5e.jpg)
![linuxHas181](https://user-images.githubusercontent.com/44300977/181867376-c568ed8a-f397-4c4d-952e-342af7837344.jpg)
