### PR TITLE
Add build workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,53 @@
+name: Build tools
+on:
+  push:
+    tags:
+      - 'v*'
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '^1.21'
+      id: go
+
+    - name: Set up nFPM
+      run: |
+        echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | sudo tee /etc/apt/sources.list.d/goreleaser.list
+        sudo apt update
+
+    - name: Install deps
+      run: sudo apt install -y build-essential cmake libcups2-dev libcupsimage2-dev tar gzip nfpm
+   
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v4
+      with:
+        lfs: true
+        fetch-depth: 0
+    
+    - name: Build
+      run: |
+        mkdir -p build
+        cd build
+        cmake ../
+        cmake --build .
+        sudo make install
+
+        tar -C / -zcvf driver.tar.gz /usr/lib/cups/filter/rastertozj /usr/share/cups/model/zjiang/zj58.ppd /usr/share/cups/model/zjiang/zj80.ppd
+
+    - name: Package
+      run: |
+        cd ci
+        yq e -i ".version = \"${GITHUB_REF_NAME/#v}\"" nfpm.yaml
+        nfpm pkg --packager deb --target ../build/zj58-amd64.deb
+
+    - name: Create release
+      run: |
+        cd build
+        gh release create --generate-notes "${GITHUB_REF_NAME}" zj58-amd64.deb driver.tar.gz
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/ci/nfpm.yaml
+++ b/ci/nfpm.yaml
@@ -1,0 +1,24 @@
+name: "zj-58"
+arch: "amd64"
+platform: "linux"
+section: "default"
+priority: "extra"
+version: "to-be-replaced"
+provides:
+- zj-58
+depends:
+- libcups2
+- libcupsimage2
+maintainer: "Aleksey N. Vinogradov  <a.n.vinogradov@gmail.com>"
+description: |
+  CUPS filter for thermal printers as Zjiang ZJ-58, XPrinter XP-58, etc 
+vendor: "Zjiang"
+homepage: "https://github.com/klirichek/zj-58"
+license: "BSD-2-Clause"
+contents:
+- src: /usr/lib/cups/filter/rastertozj
+  dst: /usr/lib/cups/filter/rastertozj
+- src: /usr/share/cups/model/zjiang/zj58.ppd
+  dst: /usr/share/cups/model/zjiang/zj58.ppd
+- src: /usr/share/cups/model/zjiang/zj80.ppd
+  dst: /usr/share/cups/model/zjiang/zj80.ppd


### PR DESCRIPTION
Adds build workflow. Creates binary archive for amd64 and Debian package.

Just push semver tag, prefixed by `v` (ex: `v1.0.0`) and GitHub action will build the package and create release.

Example build: https://github.com/reddec/zj-58/actions/runs/7544751365/job/20538794737

Example release: https://github.com/reddec/zj-58/releases/tag/v1.0.0